### PR TITLE
헤더의 위치문제 수정한 버전입니다.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,10 +18,6 @@ html{
     padding: 2vh;
 }
 
-.categorySelection{
-    padding: 2vh;
-}
-
 .cardSelection{
     padding: 2vh;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -14,4 +14,18 @@ html{
     background-position: center; 
 }
 
-  
+.searchBar{
+    padding: 2vh;
+}
+
+.categorySelection{
+    padding: 2vh;
+}
+
+.cardSelection{
+    padding: 2vh;
+}
+
+.pageSelection{
+    padding: 2vh;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -112,38 +112,41 @@ function App() {
   }
 
   return (
-    <div>
-      <Header
-        searchQuery={searchQuery}
-        handleSearchChange={handleSearchChange}
-        onSearch={handleSearch}
-      />
-
-      <Categories categories={categories} onCategoryClick={handleCategoryClick} />
-      
-      {/* 선택된 카드가 있으면 Summary를 표시 */}
-      {selectedCard ? (
-        <Summary
-          id={selectedCard.id}
-          summary={selectedCard.summary}
-          original_text={selectedCard.originalText}
-          create_at={selectedCard.createAt}
-          view_count={selectedCard.viewCount}
-          onBackClick={handleBackClick}  // 뒤로 가기 버튼 전달
-        />
-      ) : (
-        <div>
-          <Cards items={getCurrentPageCards()} onMoreClick={handleMoreClick} />  {/* onMoreClick 전달 */}
+      <div>
+        <div className='searchBar'>
+          <Header
+              searchQuery={searchQuery}
+              handleSearchChange={handleSearchChange}
+              onSearch={handleSearch}
+          />
         </div>
-      )}
-
-      <Pagination
-        total={totalCards}
-        pageSize={pageSize}
-        currentPage={currentPage}
-        onPageChange={handlePageChange}
-      />
-    </div>
+        <div className='categorySelection'>
+          <Categories categories={categories} onCategoryClick={handleCategoryClick} />
+        </div>
+        <div className='cardSelection'>
+            {selectedCard ? (
+                <Summary
+                    id={selectedCard.id}
+                    summary={selectedCard.summary}
+                    original_text={selectedCard.originalText}
+                    create_at={selectedCard.createAt}
+                    view_count={selectedCard.viewCount}
+                    onBackClick={handleBackClick}
+                />
+            ) : (
+                    <Cards items={getCurrentPageCards()} onMoreClick={handleMoreClick} />
+            )}
+            
+        </div>
+        <div className='pageSelection'>
+              <Pagination
+                  total={totalCards}
+                  pageSize={pageSize}
+                  currentPage={currentPage}
+                  onPageChange={handlePageChange}
+              />
+        </div>
+      </div>
   );
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -120,10 +120,10 @@ function App() {
               onSearch={handleSearch}
           />
         </div>
-        <div className='categorySelection'>
-          <Categories categories={categories} onCategoryClick={handleCategoryClick} />
-        </div>
+        
         <div className='cardSelection'>
+          <Categories categories={categories} onCategoryClick={handleCategoryClick} />
+
             {selectedCard ? (
                 <Summary
                     id={selectedCard.id}

--- a/src/components/Cards.jsx
+++ b/src/components/Cards.jsx
@@ -13,19 +13,21 @@ export default function Cards({ items, onMoreClick }) {
   };
 
   return (
-    <div className="cards-container">
-      <div className="cards-list">
-        {items.map((item, index) => (
-          <Card
-            key={index}
-            category={item.category}
-            summary={item.summary}
-            originalText={item.original_text}
-            createdAt={formatDate(item.created_at)} // 날짜 포맷 적용
-            viewCount={item.view_count}
-            onMoreClick={() => onMoreClick(item)}
-          />
-        ))}
+    <div className='ratioHolder'>
+      <div className="cards-container">
+        <div className="cards-list">
+          {items.map((item, index) => (
+            <Card
+              key={index}
+              category={item.category}
+              summary={item.summary}
+              originalText={item.original_text}
+              createdAt={formatDate(item.created_at)} // 날짜 포맷 적용
+              viewCount={item.view_count}
+              onMoreClick={() => onMoreClick(item)}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -5,15 +5,17 @@ import SummaryHeader from './SummaryHeader';
 
 export default function Summary({ id, summary, original_text, create_at, view_count, onBackClick }) {
     return (
-        <div className='summary-container' key={id}>
-            <SummaryHeader
-                summary={summary}
-                create_at={create_at}
-                view_count={view_count}
-                onBackClick={onBackClick}  // 뒤로 가기 버튼에 클릭 핸들러 전달
-            />
-            <div className="summary-content">
-                {original_text}
+        <div className='ratioHolder'>
+            <div className='summary-container' key={id}>
+                <SummaryHeader
+                    summary={summary}
+                    create_at={create_at}
+                    view_count={view_count}
+                    onBackClick={onBackClick}  // 뒤로 가기 버튼에 클릭 핸들러 전달
+                />
+                <div className="summary-content">
+                    {original_text}
+                </div>
             </div>
         </div>
     );

--- a/src/styles/Card.css
+++ b/src/styles/Card.css
@@ -3,13 +3,20 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: relative;
+  position: absolute;
   top: 25vh;
+}
+
+/* 비율 유지를 위한 홀더 */
+.ratioHolder {
+  width: 150vh;
+  height: 110vh;
+  position: absolute;
 }
 
 .cards-list {
   display: grid;
-  grid-template-columns: repeat(3, 1fr); /* 한 행에 4개의 카드 */
+  grid-template-columns: repeat(4, 1fr); /* 한 행에 4개의 카드 */
   gap: 2vh; /* 카드 간격 비율 */
   width: 150vh;
 }

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -6,7 +6,7 @@
     justify-content: space-between;
     position: relative;
     top: 0; /* 페이지 상단에 정확히 배치 */
-    margin-top: 75vh;
+    margin-top: 75vh; /* 현재 summary로 넘어갔을때 헤더가 과도하게 내려오는 이유 */
 }
 
 /* 제목 스타일 */

--- a/src/styles/nav.css
+++ b/src/styles/nav.css
@@ -5,6 +5,7 @@
     align-items: center;
     justify-content: center;
     top: 19vh;
+    z-index: 1; /* cardlist의 ratioHolder가 카테고리를 가려서 클릭이 안되어 placeHolder앞으로 이동 */
 }
 
 .nav-item {

--- a/src/styles/summary.css
+++ b/src/styles/summary.css
@@ -13,4 +13,5 @@
     width: 150vh;
     height: 110vh;
     position: relative;
+    left: 10vh /* 좌측으로 쏠리는 문제 해결 */
 }

--- a/src/styles/summary.css
+++ b/src/styles/summary.css
@@ -1,10 +1,16 @@
 .summary-container {
     background-color: white;
     width: 150vh;
-    height: 79vh;
+    height: 65vh;
     position: relative;
     top: 23.5vh;
     /*left: 32.5vh;*/
     border-radius: 15px;
     border: 1px solid #000;
+}
+/* 비율 유지를 위한 홀더 */
+.ratioHolder {
+    width: 150vh;
+    height: 110vh;
+    position: relative;
 }


### PR DESCRIPTION
header의 상단 패딩을 화면비율로 해놓아서 아래 컴포넌트의 비율이 바뀔때마다 헤더 위치가 바뀌는 문제가 있었습니다. 그래서 ratioHolder라는 비율을 유지해줄 컨테이너를 한층 더 감싸 안쪽의 컴포넌트의 비율 변화가 발생해도 헤더의 위치가 변하지 않게 수정하였습니다. ratioHolder가 카테고리 바를 가려 카테고리바의 z축을 수정하여 앞으로 이동시켯습니다. 문제는 해결되었으나 장기적으로 좋은 방법인지는 모르겠네요.